### PR TITLE
Implemented mock_hardware

### DIFF
--- a/auv_control_demos/chained_controllers/xacro/chained_ros2_control.xacro
+++ b/auv_control_demos/chained_controllers/xacro/chained_ros2_control.xacro
@@ -2,8 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <ros2_control name="demo_hardware" type="system">
     <hardware>
-      <plugin>mock_components/GenericSystem</plugin>
-      <param name="calculate_dynamics">false</param>
+      <plugin>mock_hardware/MockHardware</plugin>
     </hardware>
 
     <joint name="x">

--- a/auv_control_demos/individual_controller/xacro/individual_ros2_control.xacro
+++ b/auv_control_demos/individual_controller/xacro/individual_ros2_control.xacro
@@ -3,8 +3,7 @@
   <ros2_control name="demo_hardware" type="system">
 
     <hardware>
-      <plugin>mock_components/GenericSystem</plugin>
-      <param name="calculate_dynamics">false</param>
+      <plugin>mock_hardware/MockHardware</plugin>
     </hardware>
 
     <joint name="x">

--- a/mock_hardware/CMakeLists.txt
+++ b/mock_hardware/CMakeLists.txt
@@ -1,0 +1,77 @@
+cmake_minimum_required(VERSION 3.8)
+project(mock_hardware)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+  rclcpp
+  ament_cmake
+  rclcpp_lifecycle
+  pluginlib
+  hardware_interface
+)
+find_package(ament_cmake REQUIRED)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+include_directories(
+  include
+)
+
+add_library(mock_hardware SHARED
+  src/mock_hardware.cpp
+)
+
+target_include_directories(mock_hardware
+  PUBLIC
+    $<INSTALL_INTERFACE:include/mock_hardware>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_compile_features(mock_hardware PUBLIC cxx_std_17)
+target_link_libraries(mock_hardware
+  PUBLIC
+    ${rclcpp_LIBRARIES}
+)
+
+# Use dllexport instead of dllimport
+target_compile_definitions(mock_hardware PRIVATE "MOCK_HARDWARE_BUILDING_DLL")
+ament_target_dependencies(mock_hardware
+  PUBLIC
+    ${THIS_PACKAGE_INCLUDE_DEPENDS}
+)
+
+pluginlib_export_plugin_description_file(hardware_interface mock_hardware.xml)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+
+  set(ament_cmake_uncrustify_FOUND TRUE)
+
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+install(
+  DIRECTORY include/
+  DESTINATION include/mock_hardware
+)
+
+install(
+  TARGETS
+    mock_hardware
+  EXPORT
+    export_mock_hardware
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  INCLUDES DESTINATION include
+)
+
+ament_export_targets(export_mock_hardware HAS_LIBRARY_TARGET)
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+
+ament_package()

--- a/mock_hardware/CMakeLists.txt
+++ b/mock_hardware/CMakeLists.txt
@@ -50,7 +50,9 @@ pluginlib_export_plugin_description_file(hardware_interface mock_hardware.xml)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
 
+  set(ament_cmake_copyright_FOUND TRUE)
   set(ament_cmake_uncrustify_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
 
   ament_lint_auto_find_test_dependencies()
 endif()

--- a/mock_hardware/include/mock_hardware/mock_hardware.hpp
+++ b/mock_hardware/include/mock_hardware/mock_hardware.hpp
@@ -1,0 +1,105 @@
+// Copyright 2024, Everardo Gonzalez, Rakesh Vivekanandan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "hardware_interface/visibility_control.h"
+#include "mock_hardware/visibility_control.h"
+#include "rclcpp/rclcpp.hpp"
+
+namespace mock_hardware
+{
+
+/**
+ * @brief Mock hardware interface that takes a wrench vector as input and ouputs commands to CLI
+ */
+
+static constexpr size_t POSITION_INTERFACE_INDEX = 0;
+static constexpr size_t VELOCITY_INTERFACE_INDEX = 1;
+static constexpr size_t ACCELERATION_INTERFACE_INDEX = 2;
+static constexpr size_t EFFORT_INTERFACE_INDEX = 3;
+static constexpr size_t PWM_INTERFACE_INDEX = 4;
+
+class MockHardware : public hardware_interface::SystemInterface
+{
+public:
+  RCLCPP_SHARED_PTR_DEFINITIONS(MockHardware)
+
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;
+
+  hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State & previous_state) override;
+
+  hardware_interface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State & previous_state) override;
+
+  hardware_interface::return_type prepare_command_mode_switch(
+    const std::vector<std::string> & start_interfaces, const std::vector<std::string> & stop_interfaces) override;
+
+  hardware_interface::return_type perform_command_mode_switch(
+    const std::vector<std::string> & start_interfaces, const std::vector<std::string> & stop_interfaces) override;
+
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  hardware_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+  hardware_interface::return_type read(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+  hardware_interface::return_type write(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+private:
+  template <typename HandleType>
+  bool get_interface(
+    const std::string & name, const std::vector<std::string> & interface_list, const std::string & interface_name,
+    const size_t vector_index, std::vector<std::vector<double>> & values, std::vector<HandleType> & interfaces);
+
+  void initialize_storage_vectors(
+    std::vector<std::vector<double>> & commands, std::vector<std::vector<double>> & states,
+    const std::vector<std::string> & interfaces,
+    const std::vector<hardware_interface::ComponentInfo> & component_infos);
+
+  const std::vector<std::string> standard_interfaces_ = {
+    hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_VELOCITY, hardware_interface::HW_IF_ACCELERATION,
+    hardware_interface::HW_IF_EFFORT};
+
+  /// The size of this vector is (standard_interfaces_.size() x nr_joints)
+  std::vector<std::vector<double>> joint_commands_;
+  std::vector<std::vector<double>> joint_states_;
+
+  std::vector<std::string> other_interfaces_;
+  /// The size of this vector is (other_interfaces_.size() x nr_joints)
+  std::vector<std::vector<double>> other_commands_;
+  std::vector<std::vector<double>> other_states_;
+
+  std::vector<size_t> joint_control_mode_;
+};
+
+}  // namespace mock_hardware

--- a/mock_hardware/include/mock_hardware/mock_hardware.hpp
+++ b/mock_hardware/include/mock_hardware/mock_hardware.hpp
@@ -37,7 +37,7 @@ namespace mock_hardware
 {
 
 /**
- * @brief Mock hardware interface that takes a wrench vector as input and ouputs commands to CLI
+ * @brief Mock hardware interface that takes a wrench vector as input and outputs commands to CLI
  */
 
 static constexpr size_t POSITION_INTERFACE_INDEX = 0;

--- a/mock_hardware/include/mock_hardware/mock_hardware.hpp
+++ b/mock_hardware/include/mock_hardware/mock_hardware.hpp
@@ -79,7 +79,7 @@ private:
   template <typename HandleType>
   bool get_interface(
     const std::string & name, const std::vector<std::string> & interface_list, const std::string & interface_name,
-    const size_t vector_index, std::vector<std::vector<double>> & values, std::vector<HandleType> & interfaces);
+    size_t vector_index, std::vector<std::vector<double>> & values, std::vector<HandleType> & interfaces);
 
   void initialize_storage_vectors(
     std::vector<std::vector<double>> & commands, std::vector<std::vector<double>> & states,

--- a/mock_hardware/include/mock_hardware/visibility_control.h
+++ b/mock_hardware/include/mock_hardware/visibility_control.h
@@ -1,0 +1,55 @@
+// Copyright 2024, Everardo Gonzalez, Rakesh Vivekanandan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#ifndef MOCK_HARDWARE__VISIBILITY_CONTROL_H_
+#define MOCK_HARDWARE__VISIBILITY_CONTROL_H_
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+#define MOCK_HARDWARE_EXPORT __attribute__((dllexport))
+#define MOCK_HARDWARE_IMPORT __attribute__((dllimport))
+#else
+#define MOCK_HARDWARE_EXPORT __declspec(dllexport)
+#define MOCK_HARDWARE_IMPORT __declspec(dllimport)
+#endif
+#ifdef MOCK_HARDWARE_BUILDING_DLL
+#define MOCK_HARDWARE_PUBLIC MOCK_HARDWARE_EXPORT
+#else
+#define MOCK_HARDWARE_PUBLIC MOCK_HARDWARE_IMPORT
+#endif
+#define MOCK_HARDWARE_PUBLIC_TYPE MOCK_HARDWARE_PUBLIC
+#define MOCK_HARDWARE_LOCAL
+#else
+#define MOCK_HARDWARE_EXPORT __attribute__((visibility("default")))
+#define MOCK_HARDWARE_IMPORT
+#if __GNUC__ >= 4
+#define MOCK_HARDWARE_PUBLIC __attribute__((visibility("default")))
+#define MOCK_HARDWARE_LOCAL __attribute__((visibility("hidden")))
+#else
+#define MOCK_HARDWARE_PUBLIC
+#define MOCK_HARDWARE_LOCAL
+#endif
+#define MOCK_HARDWARE_PUBLIC_TYPE
+#endif
+
+#endif  // MOCK_HARDWARE__VISIBILITY_CONTROL_H_

--- a/mock_hardware/mock_hardware.xml
+++ b/mock_hardware/mock_hardware.xml
@@ -3,7 +3,7 @@
     type="mock_hardware::MockHardware"
     base_class_type="hardware_interface::SystemInterface">
     <description>
-      Mock hardware interface that takes a wrench vector as input and ouputs commands to CLI.
+      Mock hardware interface that takes a wrench vector as input and outputs commands to CLI.
     </description>
   </class>
 </library>

--- a/mock_hardware/mock_hardware.xml
+++ b/mock_hardware/mock_hardware.xml
@@ -1,0 +1,9 @@
+<library path="mock_hardware">
+  <class name="mock_hardware/MockHardware"
+    type="mock_hardware::MockHardware"
+    base_class_type="hardware_interface::SystemInterface">
+    <description>
+      Mock hardware interface that takes a wrench vector as input and ouputs commands to CLI.
+    </description>
+  </class>
+</library>

--- a/mock_hardware/package.xml
+++ b/mock_hardware/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>mock_hardware</name>
+  <version>0.0.0</version>
+  <description>A plugin interface to test auv_controllers</description>
+  <maintainer email="everardo.a.gonzalez@gmail.com">Everardo Gonzalez</maintainer>
+  <maintainer email="rakeshvivek97@gmail.com">Rakesh Vivekanandan</maintainer>
+  <license>MIT</license>
+
+  <url type="repository">https://github.com/Robotic-Decision-Making-Lab/auv_controllers.git</url>
+  <url type="bugtracker">https://github.com/Robotic-Decision-Making-Lab/auv_controllers/issues</url>
+
+  <author>Everardo Gonzalez</author>
+  <author>Rakesh Vivekanandan</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>ros2_control</depend>
+  <depend>ros2_controllers</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/mock_hardware/src/mock_hardware.cpp
+++ b/mock_hardware/src/mock_hardware.cpp
@@ -187,7 +187,7 @@ bool MockHardware::get_interface(
   return false;
 }
 
-void MockHardware::initialize_storage_vectors(
+void MockHardware::initialize_storage_vectors(  // NOLINT
   std::vector<std::vector<double>> & commands, std::vector<std::vector<double>> & states,
   const std::vector<std::string> & interfaces, const std::vector<hardware_interface::ComponentInfo> & component_infos)
 {

--- a/mock_hardware/src/mock_hardware.cpp
+++ b/mock_hardware/src/mock_hardware.cpp
@@ -1,0 +1,224 @@
+// Copyright 2024, Everardo Gonzalez, Rakesh Vivekanandan
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mock_hardware/mock_hardware.hpp"
+
+#include "hardware_interface/lexical_casts.hpp"
+
+namespace mock_hardware
+{
+
+hardware_interface::CallbackReturn MockHardware::on_init(const hardware_interface::HardwareInfo & info)
+{
+  RCLCPP_INFO(  // NOLINT
+    rclcpp::get_logger("MockHardware"), "Initializing MockHardware interface for ros2_control.");
+
+  if (hardware_interface::SystemInterface::on_init(info) != hardware_interface::CallbackReturn::SUCCESS) {
+    RCLCPP_FATAL(  // NOLINT
+      rclcpp::get_logger("MockHardware"), "Failed to initialize the MockHardware system interface.");
+
+    return hardware_interface::CallbackReturn::ERROR;
+  }
+
+  auto populate_non_standard_interfaces = [this](auto interface_list, auto & non_standard_interfaces) {
+    for (const auto & interface : interface_list) {
+      // add to list if non-standard interface
+      if (
+        std::find(standard_interfaces_.begin(), standard_interfaces_.end(), interface.name) ==
+        standard_interfaces_.end()) {
+        if (
+          std::find(non_standard_interfaces.begin(), non_standard_interfaces.end(), interface.name) ==
+          non_standard_interfaces.end()) {
+          non_standard_interfaces.emplace_back(interface.name);
+        }
+      }
+    }
+  };
+
+  // Initialize storage for standard interfaces
+  initialize_storage_vectors(joint_commands_, joint_states_, standard_interfaces_, info_.joints);
+
+  // set all values without initial values to 0
+  for (auto i = 0U; i < info_.joints.size(); i++) {
+    for (auto j = 0U; j < standard_interfaces_.size(); j++) {
+      if (std::isnan(joint_states_[j][i])) {
+        joint_states_[j][i] = 0.0;
+      }
+    }
+  }
+
+  // search for non-standard joint interfaces
+  for (const auto & joint : info_.joints) {
+    // populate non-standard command interfaces to other_interfaces_
+    populate_non_standard_interfaces(joint.command_interfaces, other_interfaces_);
+
+    // populate non-standard state interfaces to other_interfaces_
+    populate_non_standard_interfaces(joint.state_interfaces, other_interfaces_);
+  }
+
+  // Initialize storage for non-standard interfaces
+  initialize_storage_vectors(other_commands_, other_states_, other_interfaces_, info_.joints);
+
+  // Set effort control mode per default
+  joint_control_mode_.resize(info_.joints.size(), EFFORT_INTERFACE_INDEX);
+
+  RCLCPP_INFO(  // NOLINT
+    rclcpp::get_logger("MockHardware"), "Successfully initialized the MockHardware system interface!");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn MockHardware::on_configure(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(  // NOLINT
+    rclcpp::get_logger("MockHardware"), "Successfully configured the MockHardware system interface");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn MockHardware::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  RCLCPP_INFO(  // NOLINT
+    rclcpp::get_logger("MockHardware"), "Shutting down the MockHarwadre system interface.");
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn MockHardware::on_activate(const rclcpp_lifecycle::State &)
+{
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn MockHardware::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+std::vector<hardware_interface::StateInterface> MockHardware::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+
+  // Joints' state interfaces
+  for (auto i = 0U; i < info_.joints.size(); i++) {
+    const auto & joint = info_.joints[i];
+    for (const auto & interface : joint.state_interfaces) {
+      if (!get_interface(joint.name, standard_interfaces_, interface.name, i, joint_states_, state_interfaces)) {
+        if (!get_interface(joint.name, other_interfaces_, interface.name, i, other_states_, state_interfaces)) {
+          throw std::runtime_error(
+            "Interface is not found in the standard nor other list. "
+            "This should never happen!");
+        }
+      }
+    }
+  }
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface> MockHardware::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+
+  // Joints' command interfaces
+  for (size_t i = 0; i < info_.joints.size(); ++i) {
+    const auto & joint = info_.joints[i];
+    for (const auto & interface : joint.command_interfaces) {
+      if (!get_interface(joint.name, standard_interfaces_, interface.name, i, joint_commands_, command_interfaces)) {
+        if (!get_interface(joint.name, other_interfaces_, interface.name, i, other_commands_, command_interfaces)) {
+          throw std::runtime_error(
+            "Interface is not found in the standard nor other list. "
+            "This should never happen!");
+        }
+      }
+    }
+  }
+  return command_interfaces;
+}
+
+hardware_interface::return_type MockHardware::prepare_command_mode_switch(
+  const std::vector<std::string> & /* start interfaces */, const std::vector<std::string> & /* stop interfaces */)
+{
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type MockHardware::perform_command_mode_switch(
+  const std::vector<std::string> & /* start interfaces */, const std::vector<std::string> & /* stop interfaces */)
+{
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type MockHardware::read(const rclcpp::Time &, const rclcpp::Duration &)
+{
+  return hardware_interface::return_type::OK;
+}
+
+hardware_interface::return_type MockHardware::write(const rclcpp::Time &, const rclcpp::Duration &)
+{
+  return hardware_interface::return_type::OK;
+}
+
+template <typename HandleType>
+bool MockHardware::get_interface(
+  const std::string & name, const std::vector<std::string> & interface_list, const std::string & interface_name,
+  const size_t vector_index, std::vector<std::vector<double>> & values, std::vector<HandleType> & interfaces)
+{
+  auto it = std::find(interface_list.begin(), interface_list.end(), interface_name);
+  if (it != interface_list.end()) {
+    auto j = std::distance(interface_list.begin(), it);
+    interfaces.emplace_back(name, *it, &values[j][vector_index]);
+    return true;
+  }
+  return false;
+}
+
+void MockHardware::initialize_storage_vectors(
+  std::vector<std::vector<double>> & commands, std::vector<std::vector<double>> & states,
+  const std::vector<std::string> & interfaces, const std::vector<hardware_interface::ComponentInfo> & component_infos)
+{
+  // Initialize storage for all joints, regardless of their existence
+  commands.resize(interfaces.size());
+  states.resize(interfaces.size());
+  for (auto i = 0U; i < interfaces.size(); i++) {
+    commands[i].resize(component_infos.size(), std::numeric_limits<double>::quiet_NaN());
+    states[i].resize(component_infos.size(), std::numeric_limits<double>::quiet_NaN());
+  }
+
+  // Initialize with values from URDF
+  for (auto i = 0U; i < component_infos.size(); i++) {
+    const auto & component = component_infos[i];
+    for (const auto & interface : component.state_interfaces) {
+      auto it = std::find(interfaces.begin(), interfaces.end(), interface.name);
+
+      // If interface name is found in the interfaces list
+      if (it != interfaces.end()) {
+        auto index = std::distance(interfaces.begin(), it);
+
+        // Check the initial_value param is used
+        if (!interface.initial_value.empty()) {
+          states[index][i] = hardware_interface::stod(interface.initial_value);
+        }
+      }
+    }
+  }
+}
+
+}  // namespace mock_hardware
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(mock_hardware::MockHardware, hardware_interface::SystemInterface)


### PR DESCRIPTION
## Changes Made

This PR implements the mock_hardware package, which enables the testing of various types of controllers.

## Testing

Testing was performed using examples, which are included in this PR.