### PR TITLE
[Bugfix] Fix Segfault in ISMC

### DIFF
--- a/velocity_controllers/src/integral_sliding_mode_controller.cpp
+++ b/velocity_controllers/src/integral_sliding_mode_controller.cpp
@@ -39,9 +39,10 @@ namespace velocity_controllers
 namespace
 {
 
-void reset_twist_msg(std::shared_ptr<geometry_msgs::msg::Twist> msg)  // NOLINT
+void reset_twist_msg(const std::shared_ptr<geometry_msgs::msg::Twist> & m)  // NOLINT
 {
   // Make allocation of new shared_ptr explicit
+  auto msg(m);
   msg->linear.x = std::numeric_limits<double>::quiet_NaN();
   msg->linear.y = std::numeric_limits<double>::quiet_NaN();
   msg->linear.z = std::numeric_limits<double>::quiet_NaN();

--- a/velocity_controllers/src/integral_sliding_mode_controller.cpp
+++ b/velocity_controllers/src/integral_sliding_mode_controller.cpp
@@ -39,10 +39,9 @@ namespace velocity_controllers
 namespace
 {
 
-void reset_twist_msg(const std::shared_ptr<geometry_msgs::msg::Twist> & m)  // NOLINT
+void reset_twist_msg(std::shared_ptr<geometry_msgs::msg::Twist> msg)  // NOLINT
 {
   // Make allocation of new shared_ptr explicit
-  auto msg(m);
   msg->linear.x = std::numeric_limits<double>::quiet_NaN();
   msg->linear.y = std::numeric_limits<double>::quiet_NaN();
   msg->linear.z = std::numeric_limits<double>::quiet_NaN();

--- a/velocity_controllers/src/integral_sliding_mode_controller.cpp
+++ b/velocity_controllers/src/integral_sliding_mode_controller.cpp
@@ -39,8 +39,9 @@ namespace velocity_controllers
 namespace
 {
 
-void reset_twist_msg(std::shared_ptr<geometry_msgs::msg::Twist> msg)  // NOLINT
+void reset_twist_msg(const std::shared_ptr<geometry_msgs::msg::Twist> & m)  // NOLINT
 {
+  auto msg(m);
   msg->linear.x = std::numeric_limits<double>::quiet_NaN();
   msg->linear.y = std::numeric_limits<double>::quiet_NaN();
   msg->linear.z = std::numeric_limits<double>::quiet_NaN();


### PR DESCRIPTION
## Changes Made

While doing to "joystick teleop" demo, I had frequent segfaults from `controller_manager`, unpredictably after 10-60 seconds.   After building with ReleaseWithDebInfo and running in GDB, segfault was at line 262:

```
auto *current_system_state = system_state_.readFromRT();

....

reset_twist_msg(*current_reference);
```

where `current_system_state` is a `shared_ptr<Twist>`.  Handling a pointer to a shared_ptr does not increment the refcount, so I think this resulted in the shared_ptr being reaped while this function is still running.

This MR replaces the two instances of this template with:

```
auto current_system_state(*system_state_.readFromRT());

....

reset_twist_msg(current_reference);
``` 

which instantiates a `shared_ptr` for the duration of this scope.

It's possible this approach is not the most C++20-ish way to do it, happy to address it other ways.

## Associated Issues

n/a (did not open issue re segfault)

## Testing

Completed [joystick teleoperation](https://robotic-decision-making-lab.github.io/blue/tutorials/teleop/#gamepad-teleoperation) for ~10+ minutes without segfault on current `rolling` image.