### PR TITLE
Added robot state publisher to publish description

### DIFF
--- a/auv_control_demos/chained_controllers/launch/chaining.launch.py
+++ b/auv_control_demos/chained_controllers/launch/chaining.launch.py
@@ -115,11 +115,16 @@ def generate_launch_description():
 
     nodes = [
         Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="both",
+            parameters=[robot_description],
+        ),
+        Node(
             package="controller_manager",
             executable="ros2_control_node",
             output="both",
             parameters=[
-                robot_description,
                 PathJoinSubstitution(
                     [
                         FindPackageShare("auv_control_demos"),
@@ -127,6 +132,9 @@ def generate_launch_description():
                         "chained_controllers.yaml",
                     ]
                 ),
+            ],
+            remappings=[
+                ("/controller_manager/robot_description", "/robot_description"),
             ],
         ),
         *delay_thruster_spawners,

--- a/auv_control_demos/individual_controller/launch/individual.launch.py
+++ b/auv_control_demos/individual_controller/launch/individual.launch.py
@@ -48,11 +48,16 @@ def generate_launch_description():
     return LaunchDescription(
         [
             Node(
+                package="robot_state_publisher",
+                executable="robot_state_publisher",
+                output="both",
+                parameters=[robot_description],
+            ),
+            Node(
                 package="controller_manager",
                 executable="ros2_control_node",
                 output="both",
                 parameters=[
-                    robot_description,
                     PathJoinSubstitution(
                         [
                             FindPackageShare("auv_control_demos"),
@@ -60,6 +65,9 @@ def generate_launch_description():
                             "individual_controller.yaml",
                         ]
                     ),
+                ],
+                remappings=[
+                    ("/controller_manager/robot_description", "/robot_description"),
                 ],
             ),
             Node(

--- a/auv_control_demos/package.xml
+++ b/auv_control_demos/package.xml
@@ -3,7 +3,8 @@
 <package format="3">
   <name>auv_control_demos</name>
   <version>0.0.1</version>
-  <description>Example package that includes demos for using auv_controllers in individual and chained modes</description>
+  <description>Example package that includes demos for using auv_controllers in individual and
+    chained modes</description>
 
   <maintainer email="mitchcol@oregonstate.edu">Colin Mitchell</maintainer>
   <maintainer email="everardo.a.gonzalez@gmail.com">Everardo Gonzalez</maintainer>
@@ -20,6 +21,9 @@
   <author>Evan Palmer</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Changes Made

This adds the `robot_state_publisher` package to publish the robot description to a topic for the  controller manager to access.

## Associated Issues

- Fixes #25 

## Testing

Testing was done with the chained and individual controllers
