### PR TITLE
Updated ISMC to use TwistStamped instead of Twist

### DIFF
--- a/thruster_allocation_matrix_controller/include/thruster_allocation_matrix_controller/thruster_allocation_matrix_controller.hpp
+++ b/thruster_allocation_matrix_controller/include/thruster_allocation_matrix_controller/thruster_allocation_matrix_controller.hpp
@@ -75,7 +75,7 @@ protected:
 
   auto configure_parameters() -> controller_interface::CallbackReturn;
 
-  realtime_tools::RealtimeBuffer<std::shared_ptr<geometry_msgs::msg::Wrench>> reference_;
+  realtime_tools::RealtimeBuffer<geometry_msgs::msg::Wrench> reference_;
   std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::Wrench>> reference_sub_;
 
   std::shared_ptr<rclcpp::Publisher<auv_control_msgs::msg::MultiActuatorStateStamped>> controller_state_pub_;

--- a/thruster_allocation_matrix_controller/src/thruster_allocation_matrix_controller.cpp
+++ b/thruster_allocation_matrix_controller/src/thruster_allocation_matrix_controller.cpp
@@ -31,7 +31,7 @@ namespace thruster_allocation_matrix_controller
 namespace
 {
 
-auto reset_wrench_msg(std::shared_ptr<geometry_msgs::msg::Wrench> wrench_msg) -> void  // NOLINT
+auto reset_wrench_msg(geometry_msgs::msg::Wrench * wrench_msg) -> void  // NOLINT
 {
   wrench_msg->force.x = std::numeric_limits<double>::quiet_NaN();
   wrench_msg->force.y = std::numeric_limits<double>::quiet_NaN();
@@ -122,8 +122,7 @@ auto ThrusterAllocationMatrixController::on_configure(const rclcpp_lifecycle::St
     return ret;
   }
 
-  const auto reference_msg = std::make_shared<geometry_msgs::msg::Wrench>();
-  reference_.writeFromNonRT(reference_msg);
+  reference_.writeFromNonRT(geometry_msgs::msg::Wrench());
 
   command_interfaces_.reserve(num_thrusters_);
 
@@ -131,7 +130,7 @@ auto ThrusterAllocationMatrixController::on_configure(const rclcpp_lifecycle::St
     "~/reference",
     rclcpp::SystemDefaultsQoS(),
     [this](const std::shared_ptr<geometry_msgs::msg::Wrench> msg) {  // NOLINT
-      reference_.writeFromNonRT(msg);
+      reference_.writeFromNonRT(*msg);
     });
 
   controller_state_pub_ = get_node()->create_publisher<auv_control_msgs::msg::MultiActuatorStateStamped>(
@@ -153,7 +152,7 @@ auto ThrusterAllocationMatrixController::on_configure(const rclcpp_lifecycle::St
 auto ThrusterAllocationMatrixController::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
   -> controller_interface::CallbackReturn
 {
-  reset_wrench_msg(*(reference_.readFromNonRT()));
+  reset_wrench_msg(reference_.readFromNonRT());
   reference_interfaces_.assign(reference_interfaces_.size(), std::numeric_limits<double>::quiet_NaN());
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -211,12 +210,12 @@ auto ThrusterAllocationMatrixController::update_reference_from_subscribers(
   auto * current_reference = reference_.readFromNonRT();
 
   const std::vector<double> wrench = {
-    (*current_reference)->force.x,
-    (*current_reference)->force.y,
-    (*current_reference)->force.z,
-    (*current_reference)->torque.x,
-    (*current_reference)->torque.y,
-    (*current_reference)->torque.z};
+    current_reference->force.x,
+    current_reference->force.y,
+    current_reference->force.z,
+    current_reference->torque.x,
+    current_reference->torque.y,
+    current_reference->torque.z};
 
   for (std::size_t i = 0; i < wrench.size(); ++i) {
     if (!std::isnan(wrench[i])) {
@@ -224,7 +223,7 @@ auto ThrusterAllocationMatrixController::update_reference_from_subscribers(
     }
   }
 
-  reset_wrench_msg(*current_reference);
+  reset_wrench_msg(current_reference);
 
   return controller_interface::return_type::OK;
 }

--- a/thruster_controllers/include/thruster_controllers/polynomial_thrust_curve_controller.hpp
+++ b/thruster_controllers/include/thruster_controllers/polynomial_thrust_curve_controller.hpp
@@ -71,7 +71,7 @@ protected:
 
   auto configure_parameters() -> controller_interface::CallbackReturn;
 
-  realtime_tools::RealtimeBuffer<std::shared_ptr<std_msgs::msg::Float64>> reference_;
+  realtime_tools::RealtimeBuffer<std_msgs::msg::Float64> reference_;
   std::shared_ptr<rclcpp::Subscription<std_msgs::msg::Float64>> reference_sub_;
 
   std::shared_ptr<rclcpp::Publisher<control_msgs::msg::SingleDOFStateStamped>> controller_state_pub_;

--- a/thruster_controllers/src/polynomial_thrust_curve_controller.cpp
+++ b/thruster_controllers/src/polynomial_thrust_curve_controller.cpp
@@ -81,14 +81,13 @@ auto PolynomialThrustCurveController::on_configure(const rclcpp_lifecycle::State
     return ret;
   }
 
-  const auto reference_msg = std::make_shared<std_msgs::msg::Float64>();
-  reference_.writeFromNonRT(reference_msg);
+  reference_.writeFromNonRT(std_msgs::msg::Float64());
 
   command_interfaces_.reserve(1);
 
   reference_sub_ = get_node()->create_subscription<std_msgs::msg::Float64>(
     "~/reference", rclcpp::SystemDefaultsQoS(), [this](const std::shared_ptr<std_msgs::msg::Float64> msg) {  // NOLINT
-      reference_.writeFromNonRT(msg);
+      reference_.writeFromNonRT(*msg);
     });
 
   controller_state_pub_ =
@@ -107,7 +106,7 @@ auto PolynomialThrustCurveController::on_configure(const rclcpp_lifecycle::State
 auto PolynomialThrustCurveController::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
   -> controller_interface::CallbackReturn
 {
-  (*reference_.readFromNonRT())->data = std::numeric_limits<double>::quiet_NaN();
+  reference_.readFromNonRT()->data = std::numeric_limits<double>::quiet_NaN();
   reference_interfaces_.assign(reference_interfaces_.size(), std::numeric_limits<double>::quiet_NaN());
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -155,8 +154,8 @@ auto PolynomialThrustCurveController::update_reference_from_subscribers(
   const rclcpp::Duration & /*period*/) -> controller_interface::return_type
 {
   auto * current_reference = reference_.readFromNonRT();
-  reference_interfaces_[0] = (*current_reference)->data;
-  (*current_reference)->data = std::numeric_limits<double>::quiet_NaN();
+  reference_interfaces_[0] = current_reference->data;
+  current_reference->data = std::numeric_limits<double>::quiet_NaN();
 
   return controller_interface::return_type::OK;
 }

--- a/velocity_controllers/include/velocity_controllers/integral_sliding_mode_controller.hpp
+++ b/velocity_controllers/include/velocity_controllers/integral_sliding_mode_controller.hpp
@@ -30,7 +30,7 @@
 #include "control_msgs/msg/multi_dof_state_stamped.hpp"
 #include "controller_interface/chainable_controller_interface.hpp"
 #include "controller_interface/controller_interface.hpp"
-#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "hydrodynamics/eigen.hpp"
 #include "hydrodynamics/hydrodynamics.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -84,11 +84,11 @@ protected:
 
   auto configure_parameters() -> controller_interface::CallbackReturn;
 
-  realtime_tools::RealtimeBuffer<std::shared_ptr<geometry_msgs::msg::Twist>> reference_;
+  realtime_tools::RealtimeBuffer<geometry_msgs::msg::Twist> reference_;
   std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::Twist>> reference_sub_;
 
-  realtime_tools::RealtimeBuffer<std::shared_ptr<geometry_msgs::msg::Twist>> system_state_;
-  std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::Twist>> system_state_sub_;
+  realtime_tools::RealtimeBuffer<geometry_msgs::msg::Twist> system_state_;
+  std::shared_ptr<rclcpp::Subscription<geometry_msgs::msg::TwistStamped>> system_state_sub_;
   std::vector<double> system_state_values_;
 
   // We need the system rotation from the inertial frame to the vehicle frame for the hydrodynamic model.


### PR DESCRIPTION
## Changes Made

This PR makes a few changes:

1. I converted the ISMC system state subscriber from a `geometry_msgs/Twist` subscriber to a `geometry_msgs/TwistStamped` subscriber. While this information isn't technically used, it does make processing state messages that come from sensors/estimators, which are traditionally stamped messages, much easier.
2. In the process of converting the subscriber to a `TwistStamped` subscriber, I ended up modifying the `RealTimeBuffer` to use a `Twist` instead of a `shared_ptr`. While this technically introduces a slight overhead (the messages are copied now - not the pointers) and goes against the recommended approach proposed by the ros2_control folks, I think this improves readability of the code. The overhead isn't huge either because `Twist` messages aren't large. This may also address some of the issues discussed in #36 - not sure about that though. I updated the other controllers in the process to be consistent across controllers.
3. I added a log to the ISMC, reminding users that the controller will not send commands until both a valid reference and state are received.

## Associated Issues

- Fixes #26 

## Testing

Performed testing using the blue keyboard teleop demo.
